### PR TITLE
Fix crash when attribute name couldn't be found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ export default ({
             if (!attribute || !attribute.name) {
               return false;
             }
-            
+
             return attribute.name.name === 'styleName';
           });
 

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,10 @@ export default ({
       JSXElement (path: Object): void {
         const styleNameAttribute = path.node.openingElement.attributes
           .find((attribute) => {
+            if (!attribute || !attribute.name) {
+              return false;
+            }
+            
             return attribute.name.name === 'styleName';
           });
 


### PR DESCRIPTION
This fixes a crash for me in my large react environment.  Not sure why the attribute.name was null for certain classes, but this protects against it.