### PR TITLE
fix: set default value for generateScopedName

### DIFF
--- a/src/requireCssModule.js
+++ b/src/requireCssModule.js
@@ -50,8 +50,8 @@ type OptionsType = {|
 export default (cssSourceFilePath: string, options: OptionsType): StyleModuleMapType => {
   // eslint-disable-next-line prefer-const
   let runner;
-
-  const scopedName = genericNames(options.generateScopedName);
+  const localIdentName = options.generateScopedName || '[hash:base64]';
+  const scopedName = genericNames(localIdentName);
 
   const fetch = (to: string, from: string) => {
     const fromDirectoryPath = dirname(from);


### PR DESCRIPTION
this value is same as [css-loader](https://github.com/webpack/css-loader/blob/master/lib/processCss.js#L138)

fix #4
fix #28