### PR TITLE
Update to https repo URL

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,7 +1,7 @@
 # `babel-plugin-react-css-modules` usage demo
 
 ```bash
-git clone git@github.com:gajus/babel-plugin-react-css-modules.git
+git clone https://github.com/gajus/babel-plugin-react-css-modules.git
 cd ./babel-plugin-react-css-modules/demo
 npm install
 webpack-dev-server


### PR DESCRIPTION
The ~~non-secure~~ SSH github url issues a security warning and requests the user to verify the server IP and key before proceeding with the clone. Using the https URL eliminates the warning. 