### PR TITLE
Improve the module resolution error message.

### DIFF
--- a/src/getClassName.js
+++ b/src/getClassName.js
@@ -56,7 +56,7 @@ export default (styleNameValue: string, styleModuleImportMap: StyleModuleImportM
       const styleModuleMap: StyleModuleMapType = styleModuleImportMap[styleModuleImportMapKeys[0]];
 
       if (!styleModuleMap[styleName]) {
-        throw new Error('CSS module cannot be resolved.');
+        throw new Error('Could not resolve the styleName \'' + styleName + '\'.');
       }
 
       return styleModuleMap[styleName];


### PR DESCRIPTION
When a styleName fails to resolve, the current error message gives no indication of which styleName could not be found, and instead outputs the unhelpful message 'CSS module cannot be resolved.'

This PR improves that message by including the styleName and clarifying the messaging.