### PR TITLE
Support for # id selectors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -167,33 +167,33 @@ export default ({
       },
       JSXElement (path: Object, stats: Object): void {
         const filename = stats.file.opts.filename;
-        const styleNameAttribute = path.node.openingElement.attributes
+        const styleAttribute = path.node.openingElement.attributes
           .find((attribute) => {
-            return typeof attribute.name !== 'undefined' && attribute.name.name === 'styleName';
+            return typeof attribute.name !== 'undefined' && (attribute.name.name === 'styleName' || attribute.name.name === 'styleId');
           });
 
-        if (!styleNameAttribute) {
+        if (!styleAttribute) {
           return;
         }
 
-        if (t.isStringLiteral(styleNameAttribute.value)) {
+        if (t.isStringLiteral(styleAttribute.value)) {
           resolveStringLiteral(
             path,
             filenameMap[filename].styleModuleImportMap,
-            styleNameAttribute
+            styleAttribute
           );
 
           return;
         }
 
-        if (t.isJSXExpressionContainer(styleNameAttribute.value)) {
+        if (t.isJSXExpressionContainer(styleAttribute.value)) {
           if (!filenameMap[filename].importedHelperIndentifier) {
             setupFileForRuntimeResolution(path, filename);
           }
           replaceJsxExpressionContainer(
             t,
             path,
-            styleNameAttribute,
+            styleAttribute,
             filenameMap[filename].importedHelperIndentifier,
             filenameMap[filename].styleModuleImportMapIdentifier
           );

--- a/src/replaceJsxExpressionContainer.js
+++ b/src/replaceJsxExpressionContainer.js
@@ -14,11 +14,31 @@ import conditionalClassMerge from './conditionalClassMerge';
 export default (
   t: BabelTypes,
   path: Object,
-  styleNameAttribute: JSXAttribute,
+  styleAttribute: JSXAttribute,
   importedHelperIndentifier: Identifier,
   styleModuleImportMapIdentifier: Identifier
 ): void => {
-  const expressionContainerValue = styleNameAttribute.value;
+  const expressionContainerValue = styleAttribute.value;
+
+  const styleNameExpression = t.callExpression(
+    importedHelperIndentifier,
+    [
+      expressionContainerValue.expression,
+      styleModuleImportMapIdentifier
+    ]
+  );
+
+  if (styleAttribute.name.name === 'styleId') {
+    path.node.openingElement.attributes.push(jSXAttribute(
+        jSXIdentifier('id'),
+        jSXExpressionContainer(
+            styleNameExpression
+        )
+    ));
+
+    return;
+  }
+
   const classNameAttribute = path.node.openingElement.attributes
     .find((attribute) => {
       return typeof attribute.name !== 'undefined' && attribute.name.name === 'className';
@@ -28,15 +48,7 @@ export default (
     path.node.openingElement.attributes.splice(path.node.openingElement.attributes.indexOf(classNameAttribute), 1);
   }
 
-  path.node.openingElement.attributes.splice(path.node.openingElement.attributes.indexOf(styleNameAttribute), 1);
-
-  const styleNameExpression = t.callExpression(
-    importedHelperIndentifier,
-    [
-      expressionContainerValue.expression,
-      styleModuleImportMapIdentifier
-    ]
-  );
+  path.node.openingElement.attributes.splice(path.node.openingElement.attributes.indexOf(styleAttribute), 1);
 
   if (classNameAttribute) {
     if (isStringLiteral(classNameAttribute.value)) {

--- a/src/resolveStringLiteral.js
+++ b/src/resolveStringLiteral.js
@@ -15,13 +15,20 @@ import type {
 /**
  * Updates the className value of a JSX element using a provided styleName attribute.
  */
-export default (path: Object, styleModuleImportMap: StyleModuleImportMapType, styleNameAttribute: JSXAttribute): void => {
+export default (path: Object, styleModuleImportMap: StyleModuleImportMapType, styleAttribute: JSXAttribute): void => {
+  const resolvedStyleName = getClassName(styleAttribute.value.value, styleModuleImportMap);
+
+  if (styleAttribute.name.name === 'styleId') {
+    styleAttribute.name.name = 'id';
+    styleAttribute.value.value = resolvedStyleName;
+
+    return;
+  }
+
   const classNameAttribute = path.node.openingElement.attributes
     .find((attribute) => {
       return typeof attribute.name !== 'undefined' && attribute.name.name === 'className';
     });
-
-  const resolvedStyleName = getClassName(styleNameAttribute.value.value, styleModuleImportMap);
 
   if (classNameAttribute) {
     if (isStringLiteral(classNameAttribute.value)) {
@@ -35,9 +42,9 @@ export default (path: Object, styleModuleImportMap: StyleModuleImportMapType, st
       throw new Error('Unexpected attribute value.');
     }
 
-    path.node.openingElement.attributes.splice(path.node.openingElement.attributes.indexOf(styleNameAttribute), 1);
+    path.node.openingElement.attributes.splice(path.node.openingElement.attributes.indexOf(styleAttribute), 1);
   } else {
-    styleNameAttribute.name.name = 'className';
-    styleNameAttribute.value.value = resolvedStyleName;
+    styleAttribute.name.name = 'className';
+    styleAttribute.value.value = resolvedStyleName;
   }
 };


### PR DESCRIPTION
Working on a recent project I needed support for # id selectors. I see that they are being passed in but there was no transformation for them. Only classes. Using the JSX attribute 'styleId' this will override the "id" attribute and fill it with the namespaced style using either string literal/JSX expressions

Usage:

Demo.css

    #simpleEl {
       background-color: #FF0000;
    }
    
Demo.js

    import React from 'react';
    import './demo.css';

    export default () => {
      return (
        <div>
          <div styleId='simpleEl'>
          </div>
          <div styleId={'simpleEl'}>
          </div>
      ); 
    };








