### PR TITLE
Added node-sass functionality for missing classes issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-types": "^6.19.0",
     "generic-names": "^1.0.2",
+    "node-sass": "^4.5.3",
     "postcss": "^5.2.6",
     "postcss-modules": "^0.6.2",
     "postcss-modules-extract-imports": "^1.0.1",
@@ -31,9 +32,9 @@
     "flow-bin": "^0.37.4",
     "husky": "^0.12.0",
     "mocha": "^3.2.0",
-    "semantic-release": "^6.3.5",
     "postcss-less": "^0.15.0",
-    "postcss-scss": "^0.4.0"
+    "postcss-scss": "^0.4.0",
+    "semantic-release": "^6.3.5"
   },
   "engines": {
     "node": ">4.0.0"

--- a/src/requireCssModule.js
+++ b/src/requireCssModule.js
@@ -7,6 +7,7 @@ import {
 import {
   readFileSync
 } from 'fs';
+import sass from 'node-sass';
 import postcss from 'postcss';
 import genericNames from 'generic-names';
 import ExtractImports from 'postcss-modules-extract-imports';
@@ -31,8 +32,15 @@ const getTokens = (runner, cssSourceFilePath: string, filetypes): StyleModuleMap
     options.syntax = require(syntax);
   }
 
+  let fileContents = readFileSync(cssSourceFilePath, 'utf-8');
+
+  if (extension === '.scss') {
+    fileContents = sass.renderSync({file: cssSourceFilePath});
+    fileContents = fileContents.css.toString();
+  }
+
   const lazyResult = runner
-    .process(readFileSync(cssSourceFilePath, 'utf-8'), options);
+    .process(fileContents, options);
 
   lazyResult
     .warnings()


### PR DESCRIPTION
Hey!

I don't expect this to actually be merged in, but I thought the best way to describe this issue was with actually implementing a quick fix. Adding `node-sass` and hardcoding this functionality for Sass is a bit blunt.

I ran into an issue where when I'm importing files with classes in Sass (that don't also exist in the importing file), the PostCSS processor can't see the classes being imported (because it doesn't actually have them in the file until the Sass is processed). This results in a `Could not resolve the styleName` error, even though the styleName _does_ exist in the final compiled CSS file.

In order to fix this, the Sass needs to be compiled before the file is processed by this library. I think the best way to do this is probably via an option, but I couldn't think of a great way to do it right off the bat.

I also thought that this functionality might already exist, but I couldn't find any way to do it anywhere.

What do you think? And thanks for the great work on this!