### PR TITLE
Update createObjectExpression.js

### DIFF
--- a/src/createObjectExpression.js
+++ b/src/createObjectExpression.js
@@ -32,7 +32,7 @@ const createObjectExpression = (t: BabelTypes, object: InputObjectType): ObjectE
 
     properties.push(
       t.objectProperty(
-        t.identifier('\'' + name + '\''),
+        t.stringLiteral(name),
         newValue
       )
     );


### PR DESCRIPTION
From #89
`Identifiers can't have quotes. If the key is supposed to be a string, it should be t.stringLiteral(name). Because it is an identifier it is an invalid AST.`

Demo still works just fine with this, and #89 is resolved.