### PR TITLE
add new feature: make we can extract css

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
     "transform-es2015-modules-commonjs",
     "transform-es2015-parameters",
     "transform-es2015-destructuring",
+    "transform-object-rest-spread",
     "transform-flow-strip-types"
   ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,12 @@
   "extends": [
     "canonical"
   ],
+  "rules": {
+    "no-restricted-syntax": [
+      1,
+      "TemplateLiteral"
+    ],
+    "no-negated-condition": 0
+  },
   "root": true
 }

--- a/demo/.babelrc
+++ b/demo/.babelrc
@@ -1,1 +1,16 @@
-{}
+{
+  "plugins"        : [
+    "transform-object-rest-spread",
+    [
+      "react-css-modules",
+      {
+        "extractCss": {
+          "to": "lib/cssDist/myApp.css"
+        },
+        "removeImport": true,
+        "generateScopedName": "[name]___[local]___[hash:base64:2]"
+      }
+    ]
+  ],
+  "presets"        : ["flow", "es2015", "react", "stage-0"]
+}

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,5 +1,8 @@
 {
   "private": true,
+  "scripts": {
+    "build": "cd ./node_modules/.bin && babel ../../src --out-dir ../../lib"
+  },
   "dependencies": {
     "babel-plugin-react-css-modules": "^2.1.3",
     "react": "^15.4.1",
@@ -7,9 +10,21 @@
     "webpack": "^2.2.0-rc.3"
   },
   "devDependencies": {
+    "babel-cli": "^6.18.0",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-plugin-transform-es2015-destructuring": "^6.19.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
+    "babel-plugin-transform-es2015-parameters": "^6.18.0",
+    "babel-plugin-transform-flow-strip-types": "^6.18.0",
+    "flow-bin": "^0.37.4",
+
     "babel-core": "^6.21.0",
     "babel-loader": "^6.2.10",
     "babel-plugin-transform-react-jsx": "^6.8.0",
+    "babel-preset-es2015": "^6.14.0",
+    "babel-preset-flow": "^6.23.0",
+    "babel-preset-react": "^6.11.1",
+    "babel-preset-stage-0": "^6.3.13",
     "css-loader": "^0.26.1",
     "style-loader": "^0.13.1",
     "webpack-dev-server": "^2.2.0-rc.0"

--- a/demo/src/components/NamedStyleResolution.js
+++ b/demo/src/components/NamedStyleResolution.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import table from './table.css';
+import table from './table2.css';
 
 export default () => {
   return <div styleName='table.table'>

--- a/demo/src/components/table2.css
+++ b/demo/src/components/table2.css
@@ -1,0 +1,28 @@
+.table {
+  display: none;
+}
+
+.row {
+  display: none;
+}
+
+.cell {
+  display: none;
+  padding: 5555px;
+}
+
+.cell:nth-child(1) {
+  background: #111111;
+}
+
+.cell:nth-child(2) {
+  background: #111111;
+}
+
+.cell:nth-child(3) {
+  background: #111111;
+}
+
+.yellow {
+  background: #111111!important;
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-types": "^6.19.0",
     "generic-names": "^1.0.2",
+    "mkdirp": "^0.5.1",
     "postcss": "^5.2.6",
     "postcss-modules": "^0.6.2",
     "postcss-modules-extract-imports": "^1.0.1",
@@ -25,15 +26,18 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
     "babel-plugin-transform-es2015-parameters": "^6.18.0",
     "babel-plugin-transform-flow-strip-types": "^6.18.0",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.18.0",
+    "cross-env": "^5.0.0",
+    "debug": "^2.6.8",
     "eslint": "^3.11.1",
     "eslint-config-canonical": "^6.0.0",
     "flow-bin": "^0.37.4",
     "husky": "^0.12.0",
     "mocha": "^3.2.0",
-    "semantic-release": "^6.3.5",
     "postcss-less": "^0.15.0",
-    "postcss-scss": "^0.4.0"
+    "postcss-scss": "^0.4.0",
+    "semantic-release": "^6.3.5"
   },
   "engines": {
     "node": ">4.0.0"
@@ -50,11 +54,11 @@
     "url": "https://github.com/gajus/babel-plugin-react-css-modules"
   },
   "scripts": {
-    "build-helper": "mkdir -p ./dist/browser && NODE_ENV=production babel ./src/getClassName.js --out-file ./dist/browser/getClassName.js --source-maps --no-babelrc --plugins transform-es2015-modules-commonjs,transform-flow-strip-types --presets es2015",
-    "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --source-maps --copy-files && npm run build-helper",
+    "buildHelper": "mkdirp ./dist/browser && cross-env NODE_ENV=production && babel ./src/getClassName.js --out-file ./dist/browser/getClassName.js --source-maps --no-babelrc --plugins transform-es2015-modules-commonjs,transform-flow-strip-types --presets es2015",
+    "build": "cross-env NODE_ENV=production && rm -fr ./dist && babel ./src --out-dir ./dist --source-maps --copy-files && npm run buildHelper",
     "lint": "eslint ./src && flow",
     "precommit": "npm run test",
-    "test": " NODE_ENV=test mocha --compilers js:babel-register"
+    "test": "cross-env NODE_ENV=test mocha --compilers js:babel-register"
   },
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { dirname, resolve, isAbsolute } from 'path';
+import {dirname, resolve} from 'path';
 import babelPluginJsxSyntax from 'babel-plugin-syntax-jsx';
 import BabelTypes from 'babel-types';
 import Ajv from 'ajv';

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,6 @@
 // @flow
 
-import {
-  dirname,
-  resolve
-} from 'path';
+import { dirname, resolve, isAbsolute } from 'path';
 import babelPluginJsxSyntax from 'babel-plugin-syntax-jsx';
 import BabelTypes from 'babel-types';
 import Ajv from 'ajv';
@@ -155,11 +152,15 @@ export default ({
           throw new Error('Unexpected use case.');
         }
 
-        filenameMap[filename].styleModuleImportMap[styleImportName] = requireCssModule(targetResourcePath, {
-          context: stats.opts.context,
-          filetypes: stats.opts.filetypes || {},
-          generateScopedName: stats.opts.generateScopedName
-        });
+        filenameMap[filename].styleModuleImportMap[styleImportName] = requireCssModule(
+          targetResourcePath,
+          {
+            context: stats.opts.context,
+            extractCss: stats.opts.extractCss,
+            filetypes: stats.opts.filetypes || {},
+            generateScopedName: stats.opts.generateScopedName
+          }
+        );
 
         if (stats.opts.webpackHotModuleReloading) {
           addWebpackHotModuleAccept(path);

--- a/src/requireCssModule.js
+++ b/src/requireCssModule.js
@@ -55,7 +55,7 @@ const wirteCssToFile = (path, lazyResult) => {
   }
 };
 
-const getTokens = (runner, cssSourceFilePath: string, filetypes, extractCssOpts?: object): StyleModuleMapType => {
+const getTokens = (runner, cssSourceFilePath: string, filetypes, extractCssOpts): StyleModuleMapType => {
   const extension = cssSourceFilePath.substr(cssSourceFilePath.lastIndexOf('.'));
   const syntax = filetypes[extension];
 

--- a/src/requireCssModule.js
+++ b/src/requireCssModule.js
@@ -2,11 +2,15 @@
 
 import {
   dirname,
-  resolve
+  resolve,
+  basename
 } from 'path';
 import {
-  readFileSync
+  readFileSync,
+  writeFileSync,
+  appendFileSync
 } from 'fs';
+import mkdirp from 'mkdirp';
 import postcss from 'postcss';
 import genericNames from 'generic-names';
 import ExtractImports from 'postcss-modules-extract-imports';
@@ -18,7 +22,40 @@ import type {
   StyleModuleMapType
 } from './types';
 
-const getTokens = (runner, cssSourceFilePath: string, filetypes): StyleModuleMapType => {
+const writeCssFile = (filename, content) => {
+  mkdirp.sync(dirname(filename));
+  writeFileSync(filename, content);
+};
+
+const appendCssFile = (filename, content) => {
+  mkdirp.sync(dirname(filename));
+  appendFileSync(filename, content);
+};
+
+let hasWrite = false;
+const cssSourceFilePathArr = [];
+
+const wirteCssToFile = (path, lazyResult) => {
+  const correspondingMapPath = `${path}.map`;
+
+  if (!hasWrite) {
+    writeCssFile(path, lazyResult.css);
+
+    if (lazyResult.map) {
+      writeCssFile(correspondingMapPath, lazyResult.map);
+    }
+
+    hasWrite = true;
+  } else {
+    appendCssFile(path, lazyResult.css);
+
+    if (lazyResult.map) {
+      appendCssFile(correspondingMapPath, lazyResult.map);
+    }
+  }
+};
+
+const getTokens = (runner, cssSourceFilePath: string, filetypes, extractCssOpts?: object): StyleModuleMapType => {
   const extension = cssSourceFilePath.substr(cssSourceFilePath.lastIndexOf('.'));
   const syntax = filetypes[extension];
 
@@ -34,12 +71,28 @@ const getTokens = (runner, cssSourceFilePath: string, filetypes): StyleModuleMap
   const lazyResult = runner
     .process(readFileSync(cssSourceFilePath, 'utf-8'), options);
 
+  // only if the css which we import doesn't be written before,we wirte it to the file
+  if (cssSourceFilePathArr.indexOf(cssSourceFilePath) === -1 && extractCssOpts) {
+    if (extractCssOpts.to) {
+      const toPath = extractCssOpts.to;
+
+      wirteCssToFile(resolve(process.cwd(), `../../${toPath}`), lazyResult);
+    } else if (extractCssOpts.stayInOwnComponent) {
+      const filename = basename(cssSourceFilePath);
+
+      wirteCssToFile(resolve(cssSourceFilePath, `../cssModule/${filename}`), lazyResult);
+    }
+  }
+
   lazyResult
     .warnings()
     .forEach((message) => {
       // eslint-disable-next-line no-console
       console.warn(message.text);
     });
+
+  // after write css to the file,we push the path to the array to avoid we write the same css repeatedly
+  cssSourceFilePathArr.push(cssSourceFilePath);
 
   return lazyResult.root.tokens;
 };
@@ -62,7 +115,7 @@ export default (cssSourceFilePath: string, options: OptionsType): StyleModuleMap
     const fromDirectoryPath = dirname(from);
     const toPath = resolve(fromDirectoryPath, to);
 
-    return getTokens(runner, toPath, options.filetypes);
+    return getTokens(runner, toPath, options.filetypes, options.extractCss);
   };
 
   const plugins = [
@@ -79,5 +132,5 @@ export default (cssSourceFilePath: string, options: OptionsType): StyleModuleMap
 
   runner = postcss(plugins);
 
-  return getTokens(runner, cssSourceFilePath, options.filetypes);
+  return getTokens(runner, cssSourceFilePath, options.filetypes, options.extractCss);
 };

--- a/src/requireCssModule.js
+++ b/src/requireCssModule.js
@@ -99,6 +99,7 @@ const getTokens = (runner, cssSourceFilePath: string, filetypes, extractCssOpts)
 
 type OptionsType = {|
   filetypes: Object,
+  extractCss: Object,
   generateScopedName?: string,
   context?: string
 |};

--- a/src/schemas/optionsSchema.json
+++ b/src/schemas/optionsSchema.json
@@ -1,6 +1,18 @@
 {
   "additionalProperties": false,
   "properties": {
+    "extractCss": {
+      "to": {
+        "type": "string"
+      },
+      "stayInOwnComponent": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "processCss": {
+      "type": "string"
+    },
     "context": {
       "type": "string"
     },


### PR DESCRIPTION
Similar with [this pr](https://github.com/michalkvasnicak/babel-plugin-css-modules-transform/pull/16) and [this feature](https://github.com/michalkvasnicak/babel-plugin-css-modules-transform#extract-css-files)

Sorry about that I am not familiar with this repo's test framework.But believe I have did some tests.

And sorry about that I am using windows,so I have to import some extra dependencies like `cross-env`,`mkdirp` to make the command work.

If you want to test,first you should `npm run build` in the root directory and then you should copy the generated `dist` directory to this demo's `node_modules/babel-plugin-react-css-modules/dist` to make we can test.And second go to the demo's root directory,then execute `npm run build`,it will call this plugin to generate result.And you can see whether the result is what I want.

BTW,I create a new css file named `table2.css` to test whether we can extract more than one css files to just one file.There are 2 test which I have done:

1.Test extract compiled all css to one file(note that in this mode you need to add `"removeImport": true` in the option because we have extracted our css to somewhere,so if you don't do this,we will can't find the corresponding css module.And in this mode you should not use ` --copy-files` because if you do,the css you copy is still origin css. i.e. it doesn't be processed):

```
babel config:

{
  "extractCss": {
    "to": "lib/cssDist/myApp.css"
  },
  "removeImport": true,
  "generateScopedName": "[name]___[local]___[hash:base64:2]"
}

```

result:

![Imgur](http://i.imgur.com/iCUH2ex.jpg)

And you can notice that although we import `table.css` twice(in `AnonymouseStyleResolution.js` and `RuntimeStyleResolution.js`),but the result css file doesn't has duplicate content.That's what we need.

2.Test extract compiled css to their own component path of the src(note that in this mode you need to add the param `--copy-files` in your script config):

```
babel config:

{
  "extractCss": {
    "stayInOwnComponent": true
  },
  "generateScopedName": "[name]___[local]___[hash:base64:2]"
}
```

result:

![Imgur](http://i.imgur.com/kLFKpx6.jpg)