### PR TITLE
Add support for postcss-nested plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postcss-modules-parser": "^1.1.0",
     "postcss-modules-scope": "^1.0.2",
     "postcss-modules-values": "^1.2.2",
-    "postcss-nested": "^2.0.2"
+    "postcss-nested": "^1.0.1"
   },
   "description": "Transforms styleName to className using compile time CSS module resolution.",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "postcss-modules-local-by-default": "^1.1.1",
     "postcss-modules-parser": "^1.1.0",
     "postcss-modules-scope": "^1.0.2",
-    "postcss-modules-values": "^1.2.2"
+    "postcss-modules-values": "^1.2.2",
+    "postcss-nested": "^2.0.2"
   },
   "description": "Transforms styleName to className using compile time CSS module resolution.",
   "devDependencies": {

--- a/src/requireCssModule.js
+++ b/src/requireCssModule.js
@@ -11,6 +11,7 @@ import postcss from 'postcss';
 import genericNames from 'generic-names';
 import ExtractImports from 'postcss-modules-extract-imports';
 import LocalByDefault from 'postcss-modules-local-by-default';
+import Nested from 'postcss-nested';
 import Parser from 'postcss-modules-parser';
 import Scope from 'postcss-modules-scope';
 import Values from 'postcss-modules-values';
@@ -66,6 +67,7 @@ export default (cssSourceFilePath: string, options: OptionsType): StyleModuleMap
   };
 
   const plugins = [
+    Nested,
     Values,
     LocalByDefault,
     ExtractImports,

--- a/test/fixtures/react-css-modules/resolves styleName from nested class in scss/actual.js
+++ b/test/fixtures/react-css-modules/resolves styleName from nested class in scss/actual.js
@@ -1,0 +1,3 @@
+import './bar.scss';
+
+<div styleName="a_modified"></div>;

--- a/test/fixtures/react-css-modules/resolves styleName from nested class in scss/bar.scss
+++ b/test/fixtures/react-css-modules/resolves styleName from nested class in scss/bar.scss
@@ -1,0 +1,6 @@
+.a {
+    background-color: #ffffff;
+    &_modified {
+      background-color: #000000;
+    }
+}

--- a/test/fixtures/react-css-modules/resolves styleName from nested class in scss/expected.js
+++ b/test/fixtures/react-css-modules/resolves styleName from nested class in scss/expected.js
@@ -1,0 +1,3 @@
+import './bar.scss';
+
+<div className="bar__a_modified"></div>;

--- a/test/fixtures/react-css-modules/resolves styleName from nested class in scss/options.json
+++ b/test/fixtures/react-css-modules/resolves styleName from nested class in scss/options.json
@@ -1,0 +1,13 @@
+{
+  "plugins": [
+    [
+      "../../../../src",
+      {
+        "generateScopedName": "[name]__[local]",
+        "filetypes": {
+          ".scss": "postcss-scss"
+        }
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
Currently if `.scss` file contains nested classes, `postcss` doesn't generate them, so they could not be resolved. To fix that we need one more plugin in `requireCssModule.js` file. 