### PR TITLE
Support for extra postcss plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ NODE_ENV=production ./test
 |---|---|---|
 |`context`|Must match webpack [`context`](https://webpack.github.io/docs/configuration.html#context) configuration. [`css-loader`](https://github.com/webpack/css-loader) inherits `context` values from webpack. Other CSS module implementations might use different context resolution logic.|`process.cwd()`|
 |`exclude`| a RegExp that will exclude otherwise included files e.g., to exclude all styles from node_modules `exclude: 'node_modules'`|
-|`filetypes`|Configure [postcss syntax loaders](https://github.com/postcss/postcss#syntaxes) like sugerss, LESS and SCSS. ||
+|`filetypes`|Configure [postcss syntax loaders](https://github.com/postcss/postcss#syntaxes) like sugerss, LESS and SCSS and extra plugins for them. ||
 |`generateScopedName`|Refer to [Generating scoped names](https://github.com/css-modules/postcss-modules#generating-scoped-names)|`[path]___[name]__[local]___[hash:base64:5]`|
 |`removeImport`|Remove the matching style import. This option is used to enable server-side rendering.|`false`|
 |`webpackHotModuleReloading`|Enables hot reloading of CSS in webpack|`false`|
@@ -198,7 +198,20 @@ To add support for different CSS syntaxes (e.g. SCSS), perform the following two
 
   ```json
   "filetypes": {
-    ".scss": "postcss-scss"
+    ".scss": {
+      "syntax": "postcss-scss"
+    }
+  }
+  ```
+
+  And optionaly specify extra plugins
+
+  ```json
+  "filetypes": {
+    ".scss": {
+      "syntax": "postcss-scss",
+      "plugins": ["postcss-nested"]
+    }
   }
   ```
 

--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "flow-bin": "^0.37.4",
     "husky": "^0.12.0",
     "mocha": "^3.2.0",
-    "semantic-release": "^6.3.5",
     "postcss-less": "^0.15.0",
-    "postcss-scss": "^0.4.0"
+    "postcss-nested": "^1.0.1",
+    "postcss-scss": "^0.4.0",
+    "semantic-release": "^6.3.5"
   },
   "engines": {
     "node": ">4.0.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-preset-es2015": "^6.18.0",
     "eslint": "^3.11.1",
     "eslint-config-canonical": "^6.0.0",
-    "flow-bin": "^0.37.4",
+    "flow-bin": "^0.48.0",
     "husky": "^0.12.0",
     "mocha": "^3.2.0",
     "postcss-less": "^0.15.0",

--- a/src/requireCssModule.js
+++ b/src/requireCssModule.js
@@ -54,8 +54,8 @@ const getExtraPlugins = (filetypeOptions: ?(string|FileTypeOptions)): Array<any>
   }
 
   if (typeof filetypeOptions === 'object') {
-    // eslint-disable-next-line import/no-dynamic-require, global-require
     return filetypeOptions.plugins.map((plugin) => {
+      // eslint-disable-next-line import/no-dynamic-require, global-require
       return require(plugin);
     });
   }

--- a/src/requireCssModule.js
+++ b/src/requireCssModule.js
@@ -55,7 +55,9 @@ const getExtraPlugins = (filetypeOptions: ?(string|FileTypeOptions)): Array<any>
 
   if (typeof filetypeOptions === 'object') {
     // eslint-disable-next-line import/no-dynamic-require, global-require
-    return filetypeOptions.plugins.map((plugin) => { return require(plugin); });
+    return filetypeOptions.plugins.map((plugin) => {
+      return require(plugin);
+    });
   }
 
   return [];

--- a/src/requireCssModule.js
+++ b/src/requireCssModule.js
@@ -19,55 +19,47 @@ import type {
 } from './types';
 
 type FileTypeOptions = {|
-  syntax: string,
-  plugins: Array<string>
+  +syntax: string,
+  // eslint-disable-next-line no-undef
+  +plugins?: $ReadOnlyArray<string>
 |};
 
-const getFiletypeOptions = (cssSourceFilePath: string, filetypes: Object): ?(string|FileTypeOptions) => {
+const getFiletypeOptions = (cssSourceFilePath: string, filetypes: {[key: string]: FileTypeOptions}): ?FileTypeOptions => {
   const extension = cssSourceFilePath.substr(cssSourceFilePath.lastIndexOf('.'));
   const filetype = filetypes ? filetypes[extension] : null;
 
   return filetype;
 };
 
-const getSyntax = (filetypeOptions: ?(string|FileTypeOptions)) => {
+const getSyntax = (filetypeOptions: FileTypeOptions): ?(Function|Object) => {
   if (!filetypeOptions) {
     return null;
   }
 
-  if (typeof filetypeOptions === 'string') {
-    // eslint-disable-next-line import/no-dynamic-require, global-require
-    return require(filetypeOptions);
-  }
-
-  if (typeof filetypeOptions === 'object') {
-    // eslint-disable-next-line import/no-dynamic-require, global-require
-    return require(filetypeOptions.syntax);
-  }
-
-  return null;
+  // eslint-disable-next-line import/no-dynamic-require, global-require
+  return require(filetypeOptions.syntax);
 };
 
-const getExtraPlugins = (filetypeOptions: ?(string|FileTypeOptions)): Array<any> => {
-  if (!filetypeOptions) {
+// eslint-disable-next-line no-undef
+const getExtraPlugins = (filetypeOptions: ?FileTypeOptions): $ReadOnlyArray<any> => {
+  if (!filetypeOptions || !filetypeOptions.plugins) {
     return [];
   }
 
-  if (typeof filetypeOptions === 'object') {
-    return filetypeOptions.plugins.map((plugin) => {
-      // eslint-disable-next-line import/no-dynamic-require, global-require
-      return require(plugin);
-    });
-  }
-
-  return [];
+  return filetypeOptions.plugins.map((plugin) => {
+    // eslint-disable-next-line import/no-dynamic-require, global-require
+    return require(plugin);
+  });
 };
 
-const getTokens = (runner, cssSourceFilePath: string, filetypeOptions: ?(string|FileTypeOptions)): StyleModuleMapType => {
+const getTokens = (runner, cssSourceFilePath: string, filetypeOptions: ?FileTypeOptions): StyleModuleMapType => {
   const options: Object = {
-    from: cssSourceFilePath,
-    syntax: getSyntax(filetypeOptions)
+    from: cssSourceFilePath
   };
+
+  if (filetypeOptions) {
+    options.syntax = getSyntax(filetypeOptions);
+  }
 
   const lazyResult = runner
     .process(readFileSync(cssSourceFilePath, 'utf-8'), options);

--- a/src/requireCssModule.js
+++ b/src/requireCssModule.js
@@ -28,7 +28,7 @@ const getFiletypeOptions = (cssSourceFilePath: string, filetypes: Object): ?(str
   const filetype = filetypes ? filetypes[extension] : null;
 
   return filetype;
-}
+};
 
 const getSyntax = (filetypeOptions: ?(string|FileTypeOptions)) => {
   if (!filetypeOptions) {
@@ -44,21 +44,22 @@ const getSyntax = (filetypeOptions: ?(string|FileTypeOptions)) => {
     // eslint-disable-next-line import/no-dynamic-require, global-require
     return require(filetypeOptions.syntax);
   }
-}
+
+  return null;
+};
 
 const getExtraPlugins = (filetypeOptions: ?(string|FileTypeOptions)): Array<any> => {
-  console.log(filetypeOptions);
   if (!filetypeOptions) {
     return [];
   }
 
   if (typeof filetypeOptions === 'object') {
     // eslint-disable-next-line import/no-dynamic-require, global-require
-    return filetypeOptions.plugins.map(plugin => require(plugin));
+    return filetypeOptions.plugins.map((plugin) => { return require(plugin); });
   }
 
   return [];
-}
+};
 
 const getTokens = (runner, cssSourceFilePath: string, filetypeOptions: ?(string|FileTypeOptions)): StyleModuleMapType => {
   const options: Object = {

--- a/src/schemas/optionsSchema.json
+++ b/src/schemas/optionsSchema.json
@@ -11,25 +11,19 @@
       "additionalProperties": false,
       "patternProperties": {
         "\\..*": {
-          "oneOf": [
-            {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "syntax": {
               "type": "string"
             },
-            {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "syntax": {
-                  "type": "string"
-                },
-                "plugins": {
-                  "type": "array",
-                  "items": { "type": "string" },
-                  "minItems": 1
-                }
+            "plugins": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             }
-          ]
+          }
         }
       },
       "type": "object"

--- a/src/schemas/optionsSchema.json
+++ b/src/schemas/optionsSchema.json
@@ -11,7 +11,25 @@
       "additionalProperties": false,
       "patternProperties": {
         "\\..*": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "syntax": {
+                  "type": "string"
+                },
+                "plugins": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "minItems": 1
+                }
+              }
+            }
+          ]
         }
       },
       "type": "object"

--- a/test/fixtures/react-css-modules/applies extra plugins/actual.js
+++ b/test/fixtures/react-css-modules/applies extra plugins/actual.js
@@ -1,0 +1,3 @@
+import './bar.scss';
+
+<div styleName="a_modified"></div>;

--- a/test/fixtures/react-css-modules/applies extra plugins/bar.scss
+++ b/test/fixtures/react-css-modules/applies extra plugins/bar.scss
@@ -1,0 +1,7 @@
+.a {
+  background-color: #ffffff;
+  
+  &_modified {
+    background-color: #000000;
+  }
+}

--- a/test/fixtures/react-css-modules/applies extra plugins/expected.js
+++ b/test/fixtures/react-css-modules/applies extra plugins/expected.js
@@ -1,0 +1,3 @@
+import './bar.scss';
+
+<div className="bar__a_modified"></div>;

--- a/test/fixtures/react-css-modules/applies extra plugins/options.json
+++ b/test/fixtures/react-css-modules/applies extra plugins/options.json
@@ -1,0 +1,16 @@
+{
+  "plugins": [
+    [
+      "../../../../src",
+      {
+        "generateScopedName": "[name]__[local]",
+        "filetypes": {
+          ".scss": {
+            "syntax": "postcss-scss",
+            "plugins": ["postcss-nested"]
+          }
+        }
+      }
+    ]
+  ]
+}

--- a/test/fixtures/react-css-modules/resolves less stylesheets/options.json
+++ b/test/fixtures/react-css-modules/resolves less stylesheets/options.json
@@ -5,7 +5,9 @@
       {
         "generateScopedName": "[name]__[local]",
         "filetypes": {
-          ".less": "postcss-less"
+          ".less": {
+            "syntax": "postcss-less"
+          }
         }
       }
     ]


### PR DESCRIPTION
Added support for extra postcss plugins. They can be specified in `"filetypes"` section of config like this:
```json
"filetypes": {
  ".scss": {
    "syntax": "postcss-scss",
    "plugins": ["postcss-nested"]
  }
}