### PR TITLE
Prevent output file content changes between compiles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,8 +144,8 @@ export default ({
         let styleImportName: string;
 
         if (path.node.specifiers.length === 0) {
-          // eslint-disable-next-line no-process-env
-          styleImportName = process.env.NODE_ENV === 'test' ? 'random-test' : 'random-' + Math.random();
+          // use imported file path as import name
+          styleImportName = path.node.source.value;
         } else if (path.node.specifiers.length === 1) {
           styleImportName = path.node.specifiers[0].local.name;
         } else {

--- a/test/fixtures/react-css-modules/merges the resolved styleName with the existing className values/expected.js
+++ b/test/fixtures/react-css-modules/merges the resolved styleName with the existing className values/expected.js
@@ -2,7 +2,7 @@ import _getClassName from 'babel-plugin-react-css-modules/dist/browser/getClassN
 import './bar.css';
 
 const _styleModuleImportMap = {
-  'random-test': {
+  './bar.css': {
     'a': 'bar__a'
   }
 };

--- a/test/fixtures/react-css-modules/uses getClassName to resolve non-literal styleName (with already existing className)/expected.js
+++ b/test/fixtures/react-css-modules/uses getClassName to resolve non-literal styleName (with already existing className)/expected.js
@@ -6,7 +6,7 @@ const _styleModuleImportMap = {
   'bar': {
     'a-b': 'bar__a-b'
   },
-  'random-test': {
+  './foo.css': {
     'a-b': 'foo__a-b'
   }
 };

--- a/test/fixtures/react-css-modules/uses getClassName to resolve non-literal styleName/expected.js
+++ b/test/fixtures/react-css-modules/uses getClassName to resolve non-literal styleName/expected.js
@@ -6,7 +6,7 @@ const _styleModuleImportMap = {
   'bar': {
     'a-b': 'bar__a-b'
   },
-  'random-test': {
+  './foo.css': {
     'a-b': 'foo__a-b'
   }
 };


### PR DESCRIPTION
When this plugin is used, output content is changed between compiles as it uses random number in output when import is used without assign to variable (`import "./style.css";`). This causes output file hash changes between builds having equal input and long-term asset caching for web is not working.

My guess the random is used to identify imports so I replaced random with style file name and it's location in source to prevent clashes when the same file is imported multiple times (not sure if such case exists though).

Let me know if this is ok, I'm gonna adjust code style to your needs and add tests.
I guess the `process.env.NODE_ENV === 'test'` conditional and it's contents can be removed as well as `styleImportName` won't change anymore between tests?