### PR TITLE
Don't require the syntax config in filetypes

### DIFF
--- a/src/requireCssModule.js
+++ b/src/requireCssModule.js
@@ -32,7 +32,7 @@ const getFiletypeOptions = (cssSourceFilePath: string, filetypes: {[key: string]
 };
 
 const getSyntax = (filetypeOptions: FileTypeOptions): ?(Function|Object) => {
-  if (!filetypeOptions) {
+  if (!filetypeOptions || !filetypeOptions.syntax) {
     return null;
   }
 


### PR DESCRIPTION
I have a use case where we use a non `.css` extension and want to run `post-cssnext` and some other postcss plugins, but we have no specific syntax module we want to use. This change will just return null if you don't supply a syntax and still use the plugins.