### PR TITLE
Set missing default handleMissingStyleName option

### DIFF
--- a/src/getClassName.js
+++ b/src/getClassName.js
@@ -6,6 +6,8 @@ import type {
   HandleMissingStyleNameOptionType
 } from './types';
 
+const DEFAULT_HANDLE_MISSING_STYLENAME_OPTION = 'throw';
+
 const isNamespacedStyleName = (styleName: string): boolean => {
   return styleName.indexOf('.') !== -1;
 };
@@ -21,7 +23,8 @@ const getClassNameForNamespacedStyleName = (
   const styleNameParts = styleName.split('.');
   const importName = styleNameParts[0];
   const moduleName = styleNameParts[1];
-  const handleMissingStyleName = handleMissingStyleNameOption || 'throw';
+  const handleMissingStyleName = handleMissingStyleNameOption ||
+    DEFAULT_HANDLE_MISSING_STYLENAME_OPTION;
 
   if (!moduleName) {
     if (handleMissingStyleName === 'throw') {
@@ -66,7 +69,8 @@ type OptionsType = {|
 export default (styleNameValue: string, styleModuleImportMap: StyleModuleImportMapType, options?: OptionsType): string => {
   const styleModuleImportMapKeys = Object.keys(styleModuleImportMap);
 
-  const handleMissingStyleName = options && options.handleMissingStyleName;
+  const handleMissingStyleName = options && options.handleMissingStyleName ||
+    DEFAULT_HANDLE_MISSING_STYLENAME_OPTION;
 
   return styleNameValue
     .split(' ')


### PR DESCRIPTION
The default was not being set for non-namespaced styles.  This caused a bug where errors were not thrown for runtime style names, since the options are not passed in if they are only the defaults.

This can be tested by creating a dynamic `styleName` on an element, and verifying that an error is thrown.  In the currently released version, no error is thrown.  In this branch, it will be, as expected.