### PR TITLE
Adding start script to demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ npm install babel-plugin-react-css-modules --save
 git clone git@github.com:gajus/babel-plugin-react-css-modules.git
 cd ./babel-plugin-react-css-modules/demo
 npm install
-webpack-dev-server
+npm start
 ```
 
 ```bash

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,5 +1,8 @@
 {
   "private": true,
+  "scripts": {
+    "start": "webpack-dev-server"
+  },
   "dependencies": {
     "babel-plugin-react-css-modules": "^2.1.3",
     "react": "^15.4.1",


### PR DESCRIPTION
Removes the requirement that `webpack-dev-server` be installed as a global dependency