### PR TITLE
Fix multiple JSX expression replacement for Babel 7

### DIFF
--- a/src/replaceJsxExpressionContainer.js
+++ b/src/replaceJsxExpressionContainer.js
@@ -53,7 +53,7 @@ export default (
   }
 
   const styleNameExpression = t.callExpression(
-    importedHelperIndentifier,
+    t.clone(importedHelperIndentifier),
     args
   );
 


### PR DESCRIPTION
To address #137 

Output before the change:
```javascript
_react.default.createElement("div", {
  className: (0, _getClassName2.default)(..., _styleModuleImportMap)
}), _react.default.createElement("div", {
   className: _getClassName(..., _styleModuleImportMap)
...
```

After change:
```javascript
_react.default.createElement("div", {
  className: (0, _getClassName2.default)(..., _styleModuleImportMap)
}), _react.default.createElement("div", {
  className: (0, _getClassName2.default)(..., _styleModuleImportMap)
...
```

Appears to work fine with both Babel 6 and 7.