### PR TITLE
Resolve css files from context

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ export default ({
       return resolve(targetFileDirectoryPath, path.node.source.value);
     }
 
-    return require.resolve(path.node.source.value);
+    return require.resolve(path.node.source.value, {paths: [stats.opts.context]});
   };
 
   const notForPlugin = (path: *, stats: *) => {


### PR DESCRIPTION
When this babel plugin is used from an external package, say we have a `fe-tools` package which configures babel itself and provides a `fe-tools build` command, and our source code imports a 3rd-party css file, the entire folder structure could be:

```
/src
  index.js <-- import 'reset-css/reset.css'
/node_modules
  /reset-css
    reset.less
  /fe-tools
    /node_modules
      /babel-plugin-react-css-modules
```

The `require.resolve` call inside `getTargetResourcePath` function tries to resolve `reset-css/reset.css` from `node_modules/fe-tools/node_modules/babel-plugin-react-css-modules`, fails to locate the correct file and throws an error

Since we have provided a `context` option to `babel-plugin-react-css-modules`, it could try to resolve modules from that location (using `paths` option of `require.resolve`) in order to successfully locate the correct css file

I have tried `babel-plugin-module-resolver` to solve this issue but it will also introduce other problems, so I think it's better to be supported from this plugin

I think this modification is backward compatable, if not, I can add a `resolveInContext` flag for it