### PR TITLE
Add support for preprocessing with node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-types": "^6.26.0",
     "generic-names": "^1.0.3",
+    "node-sass": "^4.9.0",
     "postcss": "^6.0.22",
     "postcss-modules": "^1.1.0",
     "postcss-modules-extract-imports": "^1.1.0",

--- a/src/requireCssModule.js
+++ b/src/requireCssModule.js
@@ -7,6 +7,7 @@ import {
 import {
   readFileSync
 } from 'fs';
+import sass from 'node-sass';
 import postcss from 'postcss';
 import genericNames from 'generic-names';
 import ExtractImports from 'postcss-modules-extract-imports';
@@ -70,12 +71,19 @@ const getTokens = (runner, cssSourceFilePath: string, filetypeOptions: ?Filetype
     from: cssSourceFilePath
   };
 
+  let fileContents = readFileSync(cssSourceFilePath, 'utf-8');
+
   if (filetypeOptions) {
-    options.syntax = getSyntax(filetypeOptions);
+    if (filetypeOptions.syntax === 'node-sass') {
+      fileContents = sass.renderSync({file: cssSourceFilePath});
+      fileContents = fileContents.css.toString();
+    } else {
+      options.syntax = getSyntax(filetypeOptions);
+    }
   }
 
   const lazyResult = runner
-    .process(readFileSync(cssSourceFilePath, 'utf-8'), options);
+    .process(fileContents, options);
 
   lazyResult
     .warnings()

--- a/src/schemas/optionsSchema.json
+++ b/src/schemas/optionsSchema.json
@@ -28,6 +28,16 @@
             },
             "syntax": {
               "type": "string"
+            },
+            "importer": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array"
+                }
+              ]
             }
           },
           "type": "object"


### PR DESCRIPTION
Inspired by the great work done by @RDGthree in #90, I added some logic to allow a special `node-sass` syntax type. This adds a step wherein the file is pre-processed by `node-sass` before being passed as plain CSS to `postcss`.

This allows the babel plugin to be used with webpack's `sass-loader`, which uses a [custom importer](https://github.com/webpack-contrib/sass-loader#imports) to handle `@import`s from `node_modules`. I added an `importer` config option that takes a single importer or an array of importers. For example:
```
"plugins": [
  ["react-css-modules", {
    "filetypes": {
      ".scss": {
        "syntax": "node-sass",
        "importer": "node-sass-tilde-importer"
      }
    }
  }]
]
```

I've also published these changes as a fork (`babel-plugin-react-css-modules-sass` on npm / https://github.com/smably/babel-plugin-react-css-modules-sass on GitHub).

If there's a chance of this getting merged upstream, I'd be happy to add tests or otherwise clean this up.