### PR TITLE
fix: update build command and dependencies

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -7,14 +7,14 @@
     "babel-plugin-react-css-modules": "^2.1.3",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
-    "webpack": "^2.2.0-rc.3"
+    "webpack": "^2.7.0"
   },
   "devDependencies": {
-    "@babel/core": "^6.21.0",
-    "@babel/loader": "^6.2.10",
-    "@babel/plugin-transform-react-jsx": "^6.8.0",
+    "@babel/core": "^7.1.6",
+    "@babel/plugin-transform-react-jsx": "^7.1.6",
+    "babel-loader": "^8.0.4",
     "css-loader": "^0.26.1",
     "style-loader": "^0.13.1",
-    "webpack-dev-server": "^2.2.0-rc.0"
+    "webpack-dev-server": "^2.11.3"
   }
 }

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -18,10 +18,10 @@ module.exports = {
       },
       {
         include: path.resolve(__dirname, './src'),
-        loader: '@babel/loader',
+        loader: 'babel-loader',
         query: {
           plugins: [
-            'transform-react-jsx',
+            '@babel/transform-react-jsx',
             [
               'react-css-modules',
               {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
     "@babel/core": "^7.0.0",
     "@babel/helper-plugin-test-runner": "^7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+    "@babel/plugin-transform-modules-commonjs": "^7.1.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/register": "^7.0.0",
     "babel-core": "^7.0.0-bridge.0",
+    "babel-jest": "^23.6.0",
     "babel-plugin-tester": "^5.5.1",
     "eslint": "^5.5.0",
     "eslint-config-canonical": "^12.0.0",
@@ -66,7 +68,7 @@
   },
   "scripts": {
     "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --source-maps --copy-files && npm run build-helper",
-    "build-helper": "mkdir -p ./dist/browser && NODE_ENV=production babel ./src/getClassName.js --out-file ./dist/browser/getClassName.js --source-maps --no-babelrc --plugins transform-es2015-modules-commonjs,transform-flow-strip-types --presets es2015",
+    "build-helper": "mkdir -p ./dist/browser && NODE_ENV=production babel ./src/getClassName.js --out-file ./dist/browser/getClassName.js --source-maps --no-babelrc --plugins @babel/plugin-transform-modules-commonjs,@babel/plugin-transform-flow-strip-types --presets @babel/preset-env",
     "lint": "eslint ./src && flow",
     "test": "jest"
   },


### PR DESCRIPTION
This PR updates the presets and plugins used in the build-helper run script to use equivalent v7-packages from the @babel namespace. Additionally the demo dependencies and Webpack config are updated to make the Demo work.