### PR TITLE
fix: cannot read property 'split' of undefined

### DIFF
--- a/src/getClassName.js
+++ b/src/getClassName.js
@@ -74,7 +74,7 @@ export default (styleNameValue: string, styleModuleImportMap: StyleModuleImportM
 
   if (!styleNameValue) {
     return '';
-  };
+  }
 
   return styleNameValue
     .split(' ')

--- a/src/getClassName.js
+++ b/src/getClassName.js
@@ -72,6 +72,8 @@ export default (styleNameValue: string, styleModuleImportMap: StyleModuleImportM
   const handleMissingStyleName = options && options.handleMissingStyleName ||
     DEFAULT_HANDLE_MISSING_STYLENAME_OPTION;
 
+  if (!styleNameValue) return '';
+
   return styleNameValue
     .split(' ')
     .filter((styleName) => {

--- a/src/getClassName.js
+++ b/src/getClassName.js
@@ -72,7 +72,9 @@ export default (styleNameValue: string, styleModuleImportMap: StyleModuleImportM
   const handleMissingStyleName = options && options.handleMissingStyleName ||
     DEFAULT_HANDLE_MISSING_STYLENAME_OPTION;
 
-  if (!styleNameValue) return '';
+  if (!styleNameValue) {
+    return '';
+  };
 
   return styleNameValue
     .split(' ')


### PR DESCRIPTION
Should fix #128

In `getClassName`, falsey values will return an empty string.

Empty string is returned instead of its own value, because in cases such as `<div className="a" styleName={null} />`, the resulting className should not be `"a null"`.