### PR TITLE
fix: potential problem with default options

### DIFF
--- a/src/getClassName.js
+++ b/src/getClassName.js
@@ -87,10 +87,10 @@ const getClassNameFromMultipleImports = (
 export default (styleNameValue: string, styleModuleImportMap: StyleModuleImportMapType, options?: GetClassNameOptionsType): string => {
   const styleModuleImportMapKeys = Object.keys(styleModuleImportMap);
 
-  const handleMissingStyleName = options && options.handleMissingStyleName ||
-    optionsDefaults.handleMissingStyleName;
-
-  const autoResolveMultipleImports = options && options.autoResolveMultipleImports;
+  const {
+    handleMissingStyleName = optionsDefaults.handleMissingStyleName,
+    autoResolveMultipleImports = optionsDefaults.autoResolveMultipleImports
+  } = options || {};
 
   if (!styleNameValue) {
     return '';

--- a/src/index.js
+++ b/src/index.js
@@ -211,8 +211,10 @@ export default ({
           return;
         }
 
-        const handleMissingStyleName = stats.opts && stats.opts.handleMissingStyleName || optionsDefaults.handleMissingStyleName;
-        const autoResolveMultipleImports = stats.opts && stats.opts.autoResolveMultipleImports || optionsDefaults.autoResolveMultipleImports;
+        const {
+          handleMissingStyleName = optionsDefaults.handleMissingStyleName,
+          autoResolveMultipleImports = optionsDefaults.autoResolveMultipleImports
+        } = stats.opts || {};
 
         for (const attribute of attributes) {
           const destinationName = attributeNames[attribute.name.name];


### PR DESCRIPTION
There can be a potential bug with the options. For example if `autoResolveMultipleImports` is `false` and assuming the default is `true`,
```js
stats.opts.autoResolveMultipleImports || optionsDefaults.autoResolveMultipleImports
```
the result should not be `true`.
