### PR TITLE
Update hotmodule reloading webpack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,17 +474,17 @@ This behaviour is enabled by default in `babel-plugin-react-css-modules`.
 
 ### How to live reload the CSS?
 
-`babel-plugin-react-css-modules` utilises webpack [Hot Module Replacement](https://webpack.github.io/docs/hot-module-replacement.html) (HMR) to live reload the CSS.
+`babel-plugin-react-css-modules` utilises webpack [Hot Module Replacement](https://webpack.js.org/concepts/hot-module-replacement/#root) (HMR) to live reload the CSS.
 
 To enable live reloading of the CSS:
 
 * Enable [`webpackHotModuleReloading`](#configuration) `babel-plugin-react-css-modules` configuration.
-* Configure `webpack` to use HMR. Use [`--hot`](https://webpack.github.io/docs/webpack-dev-server.html) option if you are using `webpack-dev-server`.
+* Configure `webpack` to use HMR. Use [`--hot`](https://webpack.js.org/configuration/dev-server/#root) option if you are using `webpack-dev-server`.
 * Use [`style-loader`](https://github.com/webpack/style-loader) to load the style sheets.
 
 > Note:
 >
-> This enables live reloading of the CSS. To enable HMR of the React components, refer to the [Hot Module Replacement - React](https://webpack.js.org/guides/hmr-react/) guide.
+> This enables live reloading of the CSS. To enable HMR of the React components, refer to the [Hot Module Replacement - React](https://webpack.js.org/guides/hot-module-replacement/#other-code-and-frameworks) guide.
 
 > Note:
 >


### PR DESCRIPTION
The links to webpack's documents on hot module reloading was out of date