### PR TITLE
fix: spread should not traverse children elements

### DIFF
--- a/test/fixtures/react-css-modules/handle spread attributes/input.js
+++ b/test/fixtures/react-css-modules/handle spread attributes/input.js
@@ -20,3 +20,7 @@ const rest2 = {};
 // Should not do anything
 <div {...rest} {...rest2}></div>;
 <div {...rest} {...rest2} className="b"></div>;
+
+<div styleName="a">
+  <div {...rest} activeStyleName="a"></div>
+</div>

--- a/test/fixtures/react-css-modules/handle spread attributes/output.js
+++ b/test/fixtures/react-css-modules/handle spread attributes/output.js
@@ -14,3 +14,6 @@ const rest2 = {};
 
 <div {...rest} {...rest2}></div>;
 <div {...rest} {...rest2} className="b"></div>;
+<div className="foo__a">
+  <div {...rest} activeClassName={"foo__a" + (" " + (rest.activeClassName || ""))}></div>
+</div>;


### PR DESCRIPTION
Should fix #244 

Sorry for the bug. When traversing the spread attributes, an element traverses spread attributes in children elements as well. This fix simply changes the traversal into a simple loop. I also add a test case for this one.