### PR TITLE
Allow attributeNames destination and source attributes to be the same

### DIFF
--- a/src/replaceJsxExpressionContainer.js
+++ b/src/replaceJsxExpressionContainer.js
@@ -33,7 +33,7 @@ export default (
       return typeof attribute.name !== 'undefined' && attribute.name.name === destinationName;
     });
 
-  if (destinationAttribute) {
+  if (destinationAttribute && destinationAttribute !== sourceAttribute) {
     path.node.openingElement.attributes.splice(path.node.openingElement.attributes.indexOf(destinationAttribute), 1);
   }
 
@@ -56,7 +56,7 @@ export default (
     args
   );
 
-  if (destinationAttribute) {
+  if (destinationAttribute && destinationAttribute !== sourceAttribute) {
     if (isStringLiteral(destinationAttribute.value)) {
       path.node.openingElement.attributes.push(jSXAttribute(
         jSXIdentifier(destinationName),

--- a/src/resolveStringLiteral.js
+++ b/src/resolveStringLiteral.js
@@ -30,7 +30,7 @@ export default (
       return typeof attribute.name !== 'undefined' && attribute.name.name === destinationName;
     });
 
-  if (destinationAttribute) {
+  if (destinationAttribute && destinationAttribute !== sourceAttribute) {
     if (isStringLiteral(destinationAttribute.value)) {
       destinationAttribute.value.value += ' ' + resolvedStyleName;
     } else if (isJSXExpressionContainer(destinationAttribute.value)) {


### PR DESCRIPTION
attempt to fix the bug described in #294, where you cannot use this babel config

```json
"babel-plugin-react-css-modules": {
  "attributeNames": {
    "className": "className"
  }
}
```

by the way there's broken tests that happen even without this commit, and the number of failing tests did not change.